### PR TITLE
feat: directional feedback suggestion field (#7)

### DIFF
--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -110,7 +110,8 @@ def build_eval_prompt(contract: str, gen_report: str, code_snippets: str) -> str
 2. Identify issues from code quality, security, and performance perspectives
 3. Do not give lenient verdicts like "this is good enough"
 4. Do not trust claims in the Generator report — read and judge the code directly
-5. Respond ONLY in the following JSON format (no text outside JSON):
+5. For each issue, provide a concrete `suggestion` field describing the specific direction for fixing the issue — which file, which section, and how to change it
+6. Respond ONLY in the following JSON format (no text outside JSON):
 
 ```json
 {{
@@ -122,7 +123,8 @@ def build_eval_prompt(contract: str, gen_report: str, code_snippets: str) -> str
       "category": "functional or test or quality or performance",
       "description": "specific issue description",
       "acceptance_criterion": "AC-001",
-      "suggested_fix": "suggested fix direction"
+      "suggested_fix": "suggested fix direction",
+      "suggestion": "concrete fix direction — which file, which section, and how to change it"
     }}
   ],
   "passed_criteria": ["AC-001"],

--- a/skills/ahoy-gen/SKILL.md
+++ b/skills/ahoy-gen/SKILL.md
@@ -47,10 +47,10 @@ Explain progress to the user in natural language during implementation.
 Fixing issues found by external models.
 
 **Issues to fix** (by severity):
-| ID | Severity | Found By | Description | Fix Direction |
-|----|----------|----------|-------------|---------------|
-| ISS-001 | blocker | codex | ... | ... |
-| ISS-002 | major | claude | ... | ... |
+| ID | Severity | Found By | Description | Fix Direction | Suggestion |
+|----|----------|----------|-------------|---------------|------------|
+| ISS-001 | blocker | codex | ... | ... | (concrete fix guidance) |
+| ISS-002 | major | claude | ... | ... | (concrete fix guidance) |
 
 Starting fixes...
 ```
@@ -118,10 +118,10 @@ Starting fixes...
 ## Rework Mode
 
 If `issues.json` exists:
-1. Read each issue and reference the `suggested_fix`
+1. Read each issue and reference the `suggested_fix` and `suggestion` fields — `suggestion` contains concrete direction on which file, which section, and how to change it; use it as primary guidance for fixing
 2. Prioritize by severity: blocker > major > minor
-3. Check the `found_by` field to identify which external model found the issue
-4. If an issue cannot be fixed, record the reason in gen_report.md
+4. Check the `found_by` field to identify which external model found the issue
+5. If an issue cannot be fixed, record the reason in gen_report.md
 
 ## Test Execution
 


### PR DESCRIPTION
## Summary
- Add `suggestion` field to issues.json issue schema in `eval_dispatch.py` prompt, so external evaluator models provide concrete fix direction (which file, which section, how to change)
- Update `ahoy-gen/SKILL.md` rework mode to reference `suggestion` as primary guidance for fixing issues
- Update rework output template table to include Suggestion column

## Test plan
- [x] `python -c "import ast; ast.parse(...)"` syntax check passes
- [ ] Manual verification: run eval_dispatch.py against a sprint and confirm `suggestion` field appears in issues.json output

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)