### PR TITLE
feat: Multi-Dimensional Evaluation Perspectives (#26)

### DIFF
--- a/ahoy_config.json
+++ b/ahoy_config.json
@@ -1,6 +1,10 @@
 {
   "eval_models": ["codex", "gemini"],
   "min_models": 2,
+  "eval_perspectives": {
+    "codex": "accuracy_coverage",
+    "gemini": "security_edge"
+  },
   "cost_limit": {
     "max_eval_calls": 100,
     "max_tokens": 500000

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -1091,7 +1091,8 @@ def main() -> int:
                 tokens += estimate
         return tokens
 
-    round1_tokens = _calc_round_tokens(raw_responses, verdicts, len(prompt))
+    max_prompt_len = max(len(p) for p in model_prompts.values()) if model_prompts else len(prompt)
+    round1_tokens = _calc_round_tokens(raw_responses, verdicts, max_prompt_len)
 
     # Read the current sprint's attempt number from harness_state.json
     current_attempt = 0

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -29,6 +29,31 @@ from pathlib import Path
 # Detect Windows environment
 _IS_WINDOWS = sys.platform == "win32"
 
+PERSPECTIVES: dict[str, dict[str, str]] = {
+    "accuracy_coverage": {
+        "name": "Accuracy & Test Coverage",
+        "focus": (
+            "## Evaluation Perspective: Accuracy & Test Coverage\n\n"
+            "Focus your evaluation on:\n"
+            "- **Correctness**: Does each function produce the expected output for all inputs?\n"
+            "- **Test Coverage**: Are all code paths exercised? Are edge cases tested?\n"
+            "- **AC Satisfaction**: Is each acceptance criterion fully met with evidence?\n\n"
+            "Give secondary attention to code style and documentation.\n"
+        ),
+    },
+    "security_edge": {
+        "name": "Security & Edge Cases",
+        "focus": (
+            "## Evaluation Perspective: Security & Edge Cases\n\n"
+            "Focus your evaluation on:\n"
+            "- **Security**: Input validation, injection risks, auth/authz, secret handling\n"
+            "- **Edge Cases**: Boundary values, empty inputs, concurrent access, error paths\n"
+            "- **Robustness**: How does the code behave under unexpected conditions?\n\n"
+            "Give secondary attention to feature completeness.\n"
+        ),
+    },
+}
+
 
 def strip_generator_opinions(gen_report: str) -> str:
     """Remove Generator's self-assessment/opinions from gen_report.md, keeping only factual information.
@@ -130,7 +155,7 @@ def parse_acceptance_criteria(contract: str) -> list[dict[str, str]]:
     return criteria
 
 
-def build_eval_prompt(contract: str, gen_report: str, code_snippets: str) -> str:
+def build_eval_prompt(contract: str, gen_report: str, code_snippets: str, perspective: str | None = None) -> str:
     """Build the evaluation prompt using G-Eval 4-step Chain-of-Thought structure.
 
     Steps:
@@ -165,6 +190,10 @@ def build_eval_prompt(contract: str, gen_report: str, code_snippets: str) -> str
   ],
   "convergence_ratio": 0.75,"""
 
+    perspective_text = ""
+    if perspective and perspective in PERSPECTIVES:
+        perspective_text = "\n" + PERSPECTIVES[perspective]["focus"]
+
     return f"""You are an independent code reviewer. Evaluate the Generator's implementation using a structured 4-step Chain-of-Thought process.
 
 ## Sprint Contract (this is the evaluation criteria)
@@ -182,7 +211,7 @@ def build_eval_prompt(contract: str, gen_report: str, code_snippets: str) -> str
 2. Identify issues from code quality, security, and performance perspectives
 3. Do not give lenient verdicts like "this is good enough"
 4. Do not trust claims in the Generator report — read and judge the code directly
-
+{perspective_text}
 ## Forced Objection
 - List at least one concern or improvement, even if minor.
 - Even if the implementation looks correct, you MUST provide at least one concrete suggestion for improvement (e.g., edge cases, naming, documentation, test coverage, error handling).
@@ -991,7 +1020,14 @@ def main() -> int:
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 1
 
-    # Evaluation prompt
+    # Build per-model prompts with perspectives
+    perspectives = config.get("eval_perspectives", {})
+    model_prompts: dict[str, str] = {}
+    for model in models:
+        p = perspectives.get(model)
+        model_prompts[model] = build_eval_prompt(contract, gen_report, code_snippets, perspective=p)
+
+    # Base prompt (no perspective) for round-2 and cost estimation
     prompt = build_eval_prompt(contract, gen_report, code_snippets)
 
     # Call each model in parallel
@@ -1024,7 +1060,7 @@ def main() -> int:
     # --- Round 1 ---
     print("[eval_dispatch] Round 1: initial evaluation", file=sys.stderr)
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(models)) as executor:
-        futures = {executor.submit(_call_and_parse, m, prompt): m for m in models}
+        futures = {executor.submit(_call_and_parse, m, model_prompts[m]): m for m in models}
         for future in concurrent.futures.as_completed(futures):
             model_name, result, raw = future.result()
             verdicts[model_name] = result
@@ -1148,6 +1184,7 @@ def main() -> int:
     if round2_verdicts is not None:
         result["round2_verdicts"] = {k: v.get("verdict") for k, v in round2_verdicts.items()}
     result["status_action"] = derive_status_action(result["verdict"], result["issues"])
+    result["model_perspectives"] = {m: perspectives.get(m, "default") for m in models}
 
     # Aggregate reasoning_chain from consensus model_verdicts (already computed)
     reasoning_chains = {

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -841,3 +841,161 @@ def test_main_round2_quorum_lost_falls_back_to_round1(monkeypatch: pytest.Monkey
     # Round 2 quorum lost -> falls back to round 1, which had a fail -> final fail
     assert payload["verdict"] == "fail"
     assert exit_code == 1
+
+
+# ── v0.3.0 multi-dimensional evaluation perspectives tests ──────
+
+
+def test_build_eval_prompt_no_perspective():
+    prompt_default = eval_dispatch.build_eval_prompt("AC-001", "report", "code")
+    prompt_none = eval_dispatch.build_eval_prompt("AC-001", "report", "code", perspective=None)
+    assert prompt_default == prompt_none
+    assert "Evaluation Perspective" not in prompt_default
+
+
+def test_build_eval_prompt_with_accuracy_perspective():
+    prompt = eval_dispatch.build_eval_prompt(
+        "AC-001", "report", "code", perspective="accuracy_coverage"
+    )
+    assert "Accuracy & Test Coverage" in prompt
+    assert "Test Coverage" in prompt
+    assert "AC Satisfaction" in prompt
+
+
+def test_build_eval_prompt_with_security_perspective():
+    prompt = eval_dispatch.build_eval_prompt(
+        "AC-001", "report", "code", perspective="security_edge"
+    )
+    assert "Security & Edge Cases" in prompt
+    assert "Input validation" in prompt
+    assert "Robustness" in prompt
+
+
+def test_build_eval_prompt_unknown_perspective_ignored():
+    prompt = eval_dispatch.build_eval_prompt(
+        "AC-001", "report", "code", perspective="nonexistent_perspective"
+    )
+    assert "Evaluation Perspective" not in prompt
+
+
+def test_main_uses_per_model_prompts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    sprint_dir = tmp_path / "sprint-001"
+    project_root = tmp_path / "project"
+    sprint_dir.mkdir()
+    (sprint_dir / "contract.md").write_text("AC-001", encoding="utf-8")
+    (sprint_dir / "gen_report.md").write_text(
+        "### Files Modified\n- `scripts/example.py`\n",
+        encoding="utf-8",
+    )
+    file_path = project_root / "scripts" / "example.py"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text("print('ok')", encoding="utf-8")
+
+    captured_prompts: dict[str, str] = {}
+
+    def fake_call_model(model: str, prompt: str, timeout: int = 600) -> str:
+        captured_prompts[model] = prompt
+        return json.dumps(
+            {
+                "verdict": "pass",
+                "issues": [],
+                "passed_criteria": ["AC-001"],
+                "failed_criteria": [],
+                "summary": f"{model} pass",
+            }
+        )
+
+    monkeypatch.setattr(eval_dispatch, "call_model", fake_call_model)
+    monkeypatch.setattr(
+        eval_dispatch,
+        "load_config",
+        lambda: {
+            "eval_models": ["codex", "gemini"],
+            "min_models": 2,
+            "cost_limit": None,
+            "eval_perspectives": {
+                "codex": "accuracy_coverage",
+                "gemini": "security_edge",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        eval_dispatch.sys,
+        "argv",
+        [
+            "eval_dispatch.py",
+            str(sprint_dir),
+            "--models",
+            "codex,gemini",
+            "--project-root",
+            str(project_root),
+        ],
+    )
+
+    assert eval_dispatch.main() == 0
+
+    # Verify each model received a different perspective-focused prompt
+    assert "Accuracy & Test Coverage" in captured_prompts["codex"]
+    assert "Security & Edge Cases" not in captured_prompts["codex"]
+    assert "Security & Edge Cases" in captured_prompts["gemini"]
+    assert "Accuracy & Test Coverage" not in captured_prompts["gemini"]
+
+
+def test_result_includes_model_perspectives(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    sprint_dir = tmp_path / "sprint-001"
+    project_root = tmp_path / "project"
+    sprint_dir.mkdir()
+    (sprint_dir / "contract.md").write_text("AC-001", encoding="utf-8")
+    (sprint_dir / "gen_report.md").write_text(
+        "### Files Modified\n- `scripts/example.py`\n",
+        encoding="utf-8",
+    )
+    file_path = project_root / "scripts" / "example.py"
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text("print('ok')", encoding="utf-8")
+
+    def fake_call_model(model: str, prompt: str, timeout: int = 600) -> str:
+        return json.dumps(
+            {
+                "verdict": "pass",
+                "issues": [],
+                "passed_criteria": ["AC-001"],
+                "failed_criteria": [],
+                "summary": f"{model} pass",
+            }
+        )
+
+    monkeypatch.setattr(eval_dispatch, "call_model", fake_call_model)
+    monkeypatch.setattr(
+        eval_dispatch,
+        "load_config",
+        lambda: {
+            "eval_models": ["codex", "gemini"],
+            "min_models": 2,
+            "cost_limit": None,
+            "eval_perspectives": {
+                "codex": "accuracy_coverage",
+                "gemini": "security_edge",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        eval_dispatch.sys,
+        "argv",
+        [
+            "eval_dispatch.py",
+            str(sprint_dir),
+            "--models",
+            "codex,gemini",
+            "--project-root",
+            str(project_root),
+        ],
+    )
+
+    eval_dispatch.main()
+    payload = json.loads((sprint_dir / "issues.json").read_text(encoding="utf-8"))
+
+    assert payload["model_perspectives"] == {
+        "codex": "accuracy_coverage",
+        "gemini": "security_edge",
+    }


### PR DESCRIPTION
Closes #26

## Summary
- Add `PERSPECTIVES` dict with `accuracy_coverage` and `security_edge` evaluation perspectives
- Extend `build_eval_prompt()` to accept optional `perspective` parameter that injects focus text
- `main()` now builds per-model prompts based on `eval_perspectives` config mapping
- Result includes `model_perspectives` field showing which perspective each model used

## Test plan
- [x] `test_build_eval_prompt_no_perspective` — backward compat, no perspective text injected
- [x] `test_build_eval_prompt_with_accuracy_perspective` — accuracy focus text present
- [x] `test_build_eval_prompt_with_security_perspective` — security focus text present
- [x] `test_build_eval_prompt_unknown_perspective_ignored` — unknown key produces default prompt
- [x] `test_main_uses_per_model_prompts` — verifies different prompts sent to different models
- [x] `test_result_includes_model_perspectives` — issues.json contains model_perspectives field
- [x] All 114 tests pass, coverage 87%

🤖 Generated with [Claude Code](https://claude.com/claude-code)