### PR TITLE
feat: Stale-Read Detection Hook (#25)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "uv run python \"${CLAUDE_PLUGIN_ROOT}/scripts/validate_harness.py\" scope-check"
+          },
+          {
+            "type": "command",
+            "command": "uv run python \"${CLAUDE_PLUGIN_ROOT}/scripts/validate_harness.py\" stale-read-check"
           }
         ]
       },
@@ -70,6 +74,15 @@
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python \"${CLAUDE_PLUGIN_ROOT}/scripts/validate_harness.py\" record-read"
+          }
+        ]
+      },
       {
         "matcher": "Edit|Write",
         "hooks": [

--- a/scripts/validate_harness.py
+++ b/scripts/validate_harness.py
@@ -17,9 +17,12 @@ Usage: validate_harness.py <check_type>
     pre-push             — Run tests, lint, type check + verify state consistency before push
     post-edit-quality    — After Edit/Write: detect TODO/FIXME/stub/placeholder patterns
     circuit-breaker      — Detect repeated failure patterns across rework attempts
+    record-read          — After Read: record file hash for stale-read detection
+    stale-read-check     — Before Edit/Write: verify file has not changed since last Read
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -221,6 +224,80 @@ def fail(msg: str) -> None:
 
 def info(msg: str) -> None:
     print(msg)
+
+
+# ── Stale-read detection ──────────────────────────────────────
+
+_READ_HASH_FILE = HARNESS_DIR / ".read_hashes.json"
+
+
+def _file_hash(path: Path) -> str:
+    """Compute SHA-256 of file contents."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_read_hashes() -> dict[str, str]:
+    """Load the read hash registry."""
+    if _READ_HASH_FILE.exists():
+        try:
+            return json.loads(_READ_HASH_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def _save_read_hashes(hashes: dict[str, str]) -> None:
+    """Persist the read hash registry."""
+    _READ_HASH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _READ_HASH_FILE.write_text(json.dumps(hashes, indent=2), encoding="utf-8")
+
+
+def record_read_hash() -> None:
+    """PostToolUse Read: record the hash of the file that was just read."""
+    tool_input_raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
+    if not tool_input_raw:
+        return
+    try:
+        tool_input = json.loads(tool_input_raw)
+    except json.JSONDecodeError:
+        return
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return
+    resolved = Path(file_path)
+    if not resolved.is_file():
+        return
+    hashes = _load_read_hashes()
+    hashes[str(resolved)] = _file_hash(resolved)
+    _save_read_hashes(hashes)
+
+
+def check_stale_read() -> None:
+    """PreToolUse Edit/Write: compare current file hash to last-read hash."""
+    tool_input_raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
+    if not tool_input_raw:
+        return
+    try:
+        tool_input = json.loads(tool_input_raw)
+    except json.JSONDecodeError:
+        return
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return
+    resolved = Path(file_path)
+    if not resolved.is_file():
+        return  # New file creation — no hash to compare
+    hashes = _load_read_hashes()
+    stored_hash = hashes.get(str(resolved))
+    if stored_hash is None:
+        print(f"[HARNESS-WARN] No Read recorded for {file_path} — proceeding without stale check", file=sys.stderr)
+        return
+    current_hash = _file_hash(resolved)
+    if current_hash != stored_hash:
+        fail(
+            f"[HARNESS-GUARD] Blocked: Stale read detected for {file_path}. "
+            "File has been modified since last Read. Re-read the file before editing."
+        )
 
 
 # ── Failure pattern detection (circuit breaker) ────────────────
@@ -979,6 +1056,8 @@ CHECKS = {
     "pre-push": check_pre_push,
     "post-edit-quality": check_post_edit_quality,
     "circuit-breaker": check_circuit_breaker,
+    "record-read": record_read_hash,
+    "stale-read-check": check_stale_read,
 }
 
 

--- a/tests/test_validate_harness.py
+++ b/tests/test_validate_harness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -799,6 +800,98 @@ def test_hooks_json_covers_all_expected_check_types():
         "pre-gen", "post-eval", "guard-eval-files",
         "audit-final-scope", "pre-commit", "pre-push",
         "post-edit-quality", "circuit-breaker",
+        "record-read", "stale-read-check",
     ]
     for check in expected_checks:
         assert check in combined, f"Missing hook check: {check}"
+
+
+# ── Stale-read detection tests ────────────────────────────────
+
+
+def test_record_read_hash_stores_hash(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    harness_dir = tmp_path / ".claude" / "harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "example.py"
+    target.write_text("print('hello')", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT", json.dumps({"file_path": str(target)}))
+    monkeypatch.setattr(validate_harness, "_READ_HASH_FILE", harness_dir / ".read_hashes.json")
+
+    validate_harness.record_read_hash()
+
+    hashes = json.loads((harness_dir / ".read_hashes.json").read_text(encoding="utf-8"))
+    assert str(target) in hashes
+    expected_hash = hashlib.sha256(target.read_bytes()).hexdigest()
+    assert hashes[str(target)] == expected_hash
+
+
+def test_stale_read_passes_when_unchanged(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    harness_dir = tmp_path / ".claude" / "harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "example.py"
+    target.write_text("print('hello')", encoding="utf-8")
+    monkeypatch.setattr(validate_harness, "_READ_HASH_FILE", harness_dir / ".read_hashes.json")
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT", json.dumps({"file_path": str(target)}))
+
+    validate_harness.record_read_hash()
+    validate_harness.check_stale_read()
+
+
+def test_stale_read_blocks_when_changed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    harness_dir = tmp_path / ".claude" / "harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "example.py"
+    target.write_text("print('hello')", encoding="utf-8")
+    monkeypatch.setattr(validate_harness, "_READ_HASH_FILE", harness_dir / ".read_hashes.json")
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT", json.dumps({"file_path": str(target)}))
+
+    validate_harness.record_read_hash()
+    target.write_text("print('changed')", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        validate_harness.check_stale_read()
+
+
+def test_stale_read_allows_new_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    harness_dir = tmp_path / ".claude" / "harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(validate_harness, "_READ_HASH_FILE", harness_dir / ".read_hashes.json")
+    new_file = tmp_path / "new_file.py"
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT", json.dumps({"file_path": str(new_file)}))
+
+    validate_harness.check_stale_read()
+
+
+def test_stale_read_warns_no_read_record(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    monkeypatch.chdir(tmp_path)
+    harness_dir = tmp_path / ".claude" / "harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "example.py"
+    target.write_text("print('hello')", encoding="utf-8")
+    monkeypatch.setattr(validate_harness, "_READ_HASH_FILE", harness_dir / ".read_hashes.json")
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT", json.dumps({"file_path": str(target)}))
+
+    validate_harness.check_stale_read()
+
+    captured = capsys.readouterr()
+    assert "No Read recorded" in captured.err
+
+
+def test_stale_read_multiple_reads_uses_latest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    harness_dir = tmp_path / ".claude" / "harness"
+    harness_dir.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "example.py"
+    target.write_text("version1", encoding="utf-8")
+    monkeypatch.setattr(validate_harness, "_READ_HASH_FILE", harness_dir / ".read_hashes.json")
+    monkeypatch.setenv("CLAUDE_TOOL_INPUT", json.dumps({"file_path": str(target)}))
+
+    validate_harness.record_read_hash()
+    target.write_text("version2", encoding="utf-8")
+    validate_harness.record_read_hash()
+
+    validate_harness.check_stale_read()


### PR DESCRIPTION
Closes #25

## Summary
- Add `record_read_hash()` (PostToolUse Read) and `check_stale_read()` (PreToolUse Edit/Write) to `scripts/validate_harness.py`
- Hash registry persisted at `.claude/harness/.read_hashes.json` using SHA-256
- Blocks edits when file has changed since last Read; warns (but allows) when no Read recorded; passes for new file creation
- Hooks registered in `hooks/hooks.json` for automatic enforcement

## Test plan
- [x] `test_record_read_hash_stores_hash` — verifies hash stored after Read
- [x] `test_stale_read_passes_when_unchanged` — Read then Edit unchanged file passes
- [x] `test_stale_read_blocks_when_changed` — Read, external modify, Edit blocks
- [x] `test_stale_read_allows_new_file` — Write to non-existent file passes
- [x] `test_stale_read_warns_no_read_record` — Edit without prior Read warns but allows
- [x] `test_stale_read_multiple_reads_uses_latest` — second Read updates hash
- [x] All 114 tests pass, coverage 86.45% (>= 80%)