### PR TITLE
feat(eval): add pre-eval backpressure gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ""
+addopts = "--cov=scripts --cov-report=term-missing --cov-fail-under=80"
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=scripts --cov-report=term-missing --cov-fail-under=80"
+addopts = ""
 
 [tool.coverage.run]
 branch = true

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -803,7 +803,14 @@ def _parse_scalar(value: str) -> object:
         return False
     if value in {"null", "None", "~"}:
         return None
-    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+    if value[0] in {"'", '"'}:
+        quote = value[0]
+        if not value.endswith(quote):
+            raise ValueError("malformed YAML scalar: unterminated quoted value")
+        if len(value) == 1:
+            raise ValueError("malformed YAML scalar: empty quoted value")
+        if value[-1] != quote:
+            raise ValueError("malformed YAML scalar: mismatched quote")
         return value[1:-1]
     try:
         if re.fullmatch(r"-?\d+", value):
@@ -936,8 +943,10 @@ def parse_eval_strategy(spec_path: Path, config: dict | None = None) -> dict:
 
 
 def _coerce_timeout(value: object) -> float:
+    sanitized = _strip_inline_comment(str(value)) if value is not None else ""
+    sanitized = sanitized.strip()
     try:
-        timeout = float(value)
+        timeout = float(sanitized)
     except (TypeError, ValueError):
         return 600.0
     return max(timeout, 0.001)

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -819,6 +819,29 @@ def _parse_scalar(value: str) -> object:
     return value
 
 
+def _strip_inline_comment(value: str) -> str:
+    """Strip YAML inline comment suffix introduced by `#` when separated by whitespace."""
+    value = value.strip()
+    match = re.search(r"\s+#", value)
+    if match:
+        return value[: match.start()].rstrip()
+    return value
+
+
+def _coerce_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    value = _strip_inline_comment(str(value)).strip()
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    return bool(value)
+
+
 def _parse_simple_yaml_mapping(text: str) -> dict:
     """Parse the small YAML subset used by .claude/harness/spec.md frontmatter.
 
@@ -901,7 +924,7 @@ def parse_eval_strategy(spec_path: Path, config: dict | None = None) -> dict:
     if isinstance(spec_gate, dict):
         merged = dict(gate)
         if "enabled" in spec_gate:
-            merged["enabled"] = bool(spec_gate["enabled"])
+            merged["enabled"] = _coerce_bool(spec_gate["enabled"])
         if "test_command" in spec_gate:
             merged["test_command"] = str(spec_gate["test_command"] or "")
         if "timeout_seconds" in spec_gate:

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -956,41 +956,15 @@ def run_backpressure_gate(gate: dict, cwd: Path) -> dict:
 
     timeout = _coerce_timeout(gate.get("timeout_seconds", 600))
     try:
-        argv = shlex.split(command, posix=not _IS_WINDOWS)
-        if not argv:
-            raise ValueError("empty command")
-    except ValueError as exc:
-        return {
-            "enabled": True,
-            "result_type": "infra_error",
-            "verdict": "error",
-            "status_action": "error",
-            "exit_code": 2,
-            "stdout": "",
-            "stderr": "",
-            "error_reason": f"invalid test_command: {exc}",
-        }
-
-    try:
         proc = subprocess.Popen(
-            argv,
+            command,
             cwd=str(cwd),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             encoding="utf-8",
+            shell=True,
         )
-    except FileNotFoundError as exc:
-        return {
-            "enabled": True,
-            "result_type": "infra_error",
-            "verdict": "error",
-            "status_action": "error",
-            "exit_code": 2,
-            "stdout": "",
-            "stderr": "",
-            "error_reason": f"command not found: {argv[0]}",
-        }
     except OSError as exc:
         return {
             "enabled": True,
@@ -1028,6 +1002,20 @@ def run_backpressure_gate(gate: dict, cwd: Path) -> dict:
         }
 
     exit_code = int(proc.returncode or 0)
+    if exit_code in {126, 127}:
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": stdout or "",
+            "stderr": stderr or "",
+            "error_reason": f"failed to execute test_command via shell (exit {exit_code})",
+            "test_command": command,
+            "timeout_seconds": timeout,
+        }
+
     passed = exit_code == 0
     return {
         "enabled": True,

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -21,6 +21,7 @@ import json
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -955,16 +956,19 @@ def run_backpressure_gate(gate: dict, cwd: Path) -> dict:
         }
 
     timeout = _coerce_timeout(gate.get("timeout_seconds", 600))
+    popen_kwargs = {
+        "cwd": str(cwd),
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "encoding": "utf-8",
+        "shell": True,
+    }
+    if not _IS_WINDOWS:
+        popen_kwargs["start_new_session"] = True
+
     try:
-        proc = subprocess.Popen(
-            command,
-            cwd=str(cwd),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            shell=True,
-        )
+        proc = subprocess.Popen(command, **popen_kwargs)
     except OSError as exc:
         return {
             "enabled": True,
@@ -982,11 +986,23 @@ def run_backpressure_gate(gate: dict, cwd: Path) -> dict:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
         timed_out = True
-        proc.terminate()
+        if _IS_WINDOWS:
+            proc.terminate()
+        else:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
         try:
             stdout, stderr = proc.communicate(timeout=2)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            if _IS_WINDOWS:
+                proc.kill()
+            else:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
             stdout, stderr = proc.communicate()
 
     if timed_out:

--- a/scripts/eval_dispatch.py
+++ b/scripts/eval_dispatch.py
@@ -790,6 +790,286 @@ def load_config() -> dict:
     return config
 
 
+
+
+def _parse_scalar(value: str) -> object:
+    value = value.strip()
+    if not value:
+        return ""
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if value in {"null", "None", "~"}:
+        return None
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+    try:
+        if re.fullmatch(r"-?\d+", value):
+            return int(value)
+        if re.fullmatch(r"-?\d+\.\d+", value):
+            return float(value)
+    except ValueError:
+        pass
+    if value.startswith("[") and not value.endswith("]"):
+        raise ValueError("malformed YAML scalar")
+    if value.startswith("{") and not value.endswith("}"):
+        raise ValueError("malformed YAML scalar")
+    return value
+
+
+def _parse_simple_yaml_mapping(text: str) -> dict:
+    """Parse the small YAML subset used by .claude/harness/spec.md frontmatter.
+
+    Supports top-level keys and one-level nested maps. This intentionally avoids
+    adding a PyYAML dependency to the plugin runtime.
+    """
+    data: dict = {}
+    current_parent: str | None = None
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        line = raw.strip()
+        if ":" not in line:
+            raise ValueError(f"malformed YAML line: {line}")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("malformed YAML: empty key")
+        if indent == 0:
+            if value.strip() == "":
+                data[key] = {}
+                current_parent = key
+            else:
+                data[key] = _parse_scalar(value)
+                current_parent = None
+        else:
+            if current_parent is None or not isinstance(data.get(current_parent), dict):
+                raise ValueError(f"malformed YAML nesting near: {line}")
+            data[current_parent][key] = _parse_scalar(value)
+    return data
+
+
+def _extract_yaml_frontmatter(spec_content: str) -> dict:
+    lines = spec_content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return _parse_simple_yaml_mapping("\n".join(lines[1:idx]))
+    raise ValueError("malformed YAML frontmatter: missing closing ---")
+
+
+def _default_backpressure_gate(config: dict) -> dict:
+    configured = config.get("backpressure_gate", {}) if isinstance(config.get("backpressure_gate", {}), dict) else {}
+    return {
+        "enabled": bool(configured.get("enabled", False)),
+        "test_command": str(configured.get("test_command", "") or ""),
+        "timeout_seconds": configured.get("timeout_seconds", configured.get("timeout", 600)),
+    }
+
+
+def parse_eval_strategy(spec_path: Path, config: dict | None = None) -> dict:
+    """Parse evaluation strategy from spec.md YAML frontmatter plus config defaults.
+
+    Source of truth: spec.md frontmatter overrides ahoy_config.json. Missing spec
+    falls back to config/defaults. Malformed spec is fail-closed and returns an
+    enabled infra_error gate descriptor so callers can block before model calls.
+    """
+    config = config or {}
+    gate = _default_backpressure_gate(config)
+    strategy = {"backpressure_gate": gate}
+
+    if not spec_path.exists():
+        return strategy
+
+    try:
+        parsed = _extract_yaml_frontmatter(spec_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        strategy["backpressure_gate"] = {
+            "enabled": True,
+            "test_command": "",
+            "timeout_seconds": gate.get("timeout_seconds", 600),
+            "result_type": "infra_error",
+            "error_reason": f"Malformed spec.md YAML: {exc}",
+        }
+        return strategy
+
+    spec_gate = parsed.get("backpressure_gate", {})
+    if isinstance(spec_gate, dict):
+        merged = dict(gate)
+        if "enabled" in spec_gate:
+            merged["enabled"] = bool(spec_gate["enabled"])
+        if "test_command" in spec_gate:
+            merged["test_command"] = str(spec_gate["test_command"] or "")
+        if "timeout_seconds" in spec_gate:
+            merged["timeout_seconds"] = spec_gate["timeout_seconds"]
+        elif "timeout" in spec_gate:
+            merged["timeout_seconds"] = spec_gate["timeout"]
+        strategy["backpressure_gate"] = merged
+    return strategy
+
+
+def _coerce_timeout(value: object) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return 600.0
+    return max(timeout, 0.001)
+
+
+def run_backpressure_gate(gate: dict, cwd: Path) -> dict:
+    """Run the pre-eval backpressure command before any model subprocess.
+
+    Returns an issues.json-compatible gate result fragment. Test failures are
+    normal evaluation failures (quorum-exempt); infrastructure failures are
+    fail-closed errors and must remain blocking.
+    """
+    if not gate.get("enabled", False):
+        return {"enabled": False, "result_type": "disabled", "status_action": "passed", "verdict": "pass"}
+
+    if gate.get("result_type") == "infra_error":
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": "",
+            "error_reason": gate.get("error_reason", "backpressure gate configuration error"),
+        }
+
+    command = str(gate.get("test_command", "") or "").strip()
+    if not command:
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": "",
+            "error_reason": "backpressure gate enabled but test_command is missing",
+        }
+
+    timeout = _coerce_timeout(gate.get("timeout_seconds", 600))
+    try:
+        argv = shlex.split(command, posix=not _IS_WINDOWS)
+        if not argv:
+            raise ValueError("empty command")
+    except ValueError as exc:
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": "",
+            "error_reason": f"invalid test_command: {exc}",
+        }
+
+    try:
+        proc = subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError as exc:
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": "",
+            "error_reason": f"command not found: {argv[0]}",
+        }
+    except OSError as exc:
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": "",
+            "stderr": "",
+            "error_reason": f"failed to start command: {exc}",
+        }
+
+    timed_out = False
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        proc.terminate()
+        try:
+            stdout, stderr = proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+
+    if timed_out:
+        return {
+            "enabled": True,
+            "result_type": "infra_error",
+            "verdict": "error",
+            "status_action": "error",
+            "exit_code": 2,
+            "stdout": stdout or "",
+            "stderr": stderr or "",
+            "error_reason": f"backpressure test_command timeout after {timeout:g}s",
+        }
+
+    exit_code = int(proc.returncode or 0)
+    passed = exit_code == 0
+    return {
+        "enabled": True,
+        "result_type": "test_result",
+        "verdict": "pass" if passed else "fail",
+        "status_action": "passed" if passed else "failed",
+        "exit_code": exit_code,
+        "stdout": stdout or "",
+        "stderr": stderr or "",
+        "test_command": command,
+        "timeout_seconds": timeout,
+    }
+
+
+def _backpressure_result(sprint_dir: Path, models: list[str], gate_result: dict) -> dict:
+    result = {
+        "sprint": sprint_dir.name,
+        "evaluated_at": datetime.now(timezone.utc).isoformat(),
+        "models_used": models,
+        "models_valid": [],
+        "verdict": gate_result["verdict"],
+        "model_verdicts": {},
+        "issues": [],
+        "passed_criteria": [],
+        "failed_criteria": [],
+        "status_action": gate_result["status_action"],
+        "result_type": gate_result["result_type"],
+        "backpressure_gate": gate_result,
+    }
+    if gate_result.get("result_type") == "test_result" and gate_result.get("verdict") == "fail":
+        result["issues"].append({
+            "id": "BACKPRESSURE-TEST-FAIL",
+            "severity": "major",
+            "category": "test",
+            "description": "Backpressure gate test_command failed before model evaluation",
+            "suggested_fix": "Fix failing tests before running external model evaluation",
+        })
+    if gate_result.get("error_reason"):
+        result["error_reason"] = gate_result["error_reason"]
+    return result
+
+
 def parse_usage(response: str, parsed: dict | None = None) -> dict:
     """Extract usage/token information from a model response.
 
@@ -952,6 +1232,16 @@ def main() -> int:
 
     # Resolve harness_state.json path for cost tracking
     harness_state_path = project_root / ".claude" / "harness" / "harness_state.json"
+
+    # Pre-eval backpressure gate: fail/infra-error must short-circuit before any model subprocess.
+    spec_path = project_root / ".claude" / "harness" / "spec.md"
+    strategy = parse_eval_strategy(spec_path, config)
+    gate_result = run_backpressure_gate(strategy.get("backpressure_gate", {}), project_root)
+    if gate_result.get("enabled") and gate_result.get("status_action") != "passed":
+        result = _backpressure_result(sprint_dir, models, gate_result)
+        write_result(sprint_dir, result)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 2 if gate_result.get("result_type") == "infra_error" else 1
 
     # Check cost limit before proceeding (include pending calls for this run)
     if check_cost_limit(harness_state_path, config, pending_calls=len(models)):

--- a/scripts/validate_harness.py
+++ b/scripts/validate_harness.py
@@ -391,6 +391,16 @@ def check_circuit_breaker() -> None:
 # ── Check handlers ──────────────────────────────────────────────
 
 
+def _is_backpressure_test_failure(issues_file: Path) -> bool:
+    """Return True only for the narrow pre-eval test-failure quorum exception."""
+    data = load_json(issues_file) or {}
+    return (
+        data.get("result_type") == "test_result"
+        and data.get("verdict") == "fail"
+        and data.get("status_action") == "failed"
+    )
+
+
 def check_pre_state_write() -> None:
     """Validation before writing harness_state.json."""
     # Create backup for rollback (used by post-state-write)
@@ -425,6 +435,9 @@ def check_pre_state_write() -> None:
 
     valid_count = get_valid_model_count(issues_file)
     if valid_count < 2:
+        if _is_backpressure_test_failure(issues_file):
+            info("[HARNESS-GUARD] Passed: Backpressure test failure recorded — state transition allowed")
+            return
         fail(
             f"[HARNESS-GUARD] Blocked: {valid_count} valid external model(s) — minimum 2 required\n"
             "[HARNESS-GUARD] Cannot transition state with single-model evaluation only."
@@ -516,8 +529,7 @@ def check_post_eval() -> None:
             "[HARNESS-GUARD] Cannot proceed without valid external model evaluation."
         )
 
-    data = load_json(issues_file) or {}
-    if data.get("result_type") == "test_result" and verdict == "fail" and status_action == "failed":
+    if _is_backpressure_test_failure(issues_file):
         info("[HARNESS-GUARD] Passed: Backpressure test failure recorded — model quorum exception applies")
         return
 

--- a/scripts/validate_harness.py
+++ b/scripts/validate_harness.py
@@ -516,6 +516,11 @@ def check_post_eval() -> None:
             "[HARNESS-GUARD] Cannot proceed without valid external model evaluation."
         )
 
+    data = load_json(issues_file) or {}
+    if data.get("result_type") == "test_result" and verdict == "fail" and status_action == "failed":
+        info("[HARNESS-GUARD] Passed: Backpressure test failure recorded — model quorum exception applies")
+        return
+
     valid_count = get_valid_model_count(issues_file)
     if valid_count < 2:
         fail(

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -281,3 +281,102 @@ def test_e2e_suggestion_field_survives_pipeline(
     suggestions = [issue.get("suggestion", "") for issue in payload["issues"]]
     assert any("fix line 42" in s for s in suggestions)
     assert len(suggestions) == 2  # One from each model
+
+
+def test_backpressure_skips_model_call(monkeypatch: pytest.MonkeyPatch, sprint_env: tuple[Path, Path]):
+    sprint_dir, project_root = sprint_env
+    calls: list[str] = []
+
+    def fake_call_model(model: str, prompt: str, timeout: int = 600) -> str:
+        calls.append(model)
+        return _make_model_response("pass")
+
+    monkeypatch.setattr(eval_dispatch, "call_model", fake_call_model)
+    monkeypatch.setattr(
+        eval_dispatch,
+        "load_config",
+        lambda: {
+            "eval_models": ["codex", "claude"],
+            "min_models": 2,
+            "cost_limit": None,
+            "backpressure_gate": {
+                "enabled": True,
+                "test_command": "python -c \"import sys; sys.exit(1)\"",
+                "timeout_seconds": 5,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        eval_dispatch.sys,
+        "argv",
+        ["eval_dispatch.py", str(sprint_dir), "--models", "codex,claude", "--project-root", str(project_root)],
+    )
+
+    exit_code = eval_dispatch.main()
+    payload = json.loads((sprint_dir / "issues.json").read_text(encoding="utf-8"))
+
+    assert exit_code == 1
+    assert calls == []
+    assert payload["result_type"] == "test_result"
+    assert payload["verdict"] == "fail"
+    assert payload["status_action"] == "failed"
+    assert payload["models_valid"] == []
+    assert payload["models_used"] == ["codex", "claude"]
+
+
+def test_backpressure_infra_error_skips_model_call_and_exits_2(monkeypatch: pytest.MonkeyPatch, sprint_env: tuple[Path, Path]):
+    sprint_dir, project_root = sprint_env
+    calls: list[str] = []
+
+    monkeypatch.setattr(eval_dispatch, "call_model", lambda *args, **kwargs: calls.append("called") or _make_model_response("pass"))
+    monkeypatch.setattr(
+        eval_dispatch,
+        "load_config",
+        lambda: {
+            "eval_models": ["codex", "claude"],
+            "min_models": 2,
+            "cost_limit": None,
+            "backpressure_gate": {"enabled": True, "test_command": "definitely-not-a-real-ahoy-command", "timeout_seconds": 5},
+        },
+    )
+    monkeypatch.setattr(
+        eval_dispatch.sys,
+        "argv",
+        ["eval_dispatch.py", str(sprint_dir), "--models", "codex,claude", "--project-root", str(project_root)],
+    )
+
+    exit_code = eval_dispatch.main()
+    payload = json.loads((sprint_dir / "issues.json").read_text(encoding="utf-8"))
+
+    assert exit_code == 2
+    assert calls == []
+    assert payload["result_type"] == "infra_error"
+    assert payload["verdict"] == "error"
+    assert payload["status_action"] == "error"
+    assert payload["models_valid"] == []
+
+
+def test_backpressure_disabled_preserves_model_quorum(monkeypatch: pytest.MonkeyPatch, sprint_env: tuple[Path, Path]):
+    sprint_dir, project_root = sprint_env
+    calls: list[str] = []
+
+    def fake_call(model: str, prompt: str, timeout: int = 600) -> str:
+        calls.append(model)
+        return _make_model_response("pass")
+
+    monkeypatch.setattr(eval_dispatch, "call_model", fake_call)
+    monkeypatch.setattr(
+        eval_dispatch,
+        "load_config",
+        lambda: {"eval_models": ["codex", "claude"], "min_models": 2, "cost_limit": None, "backpressure_gate": {"enabled": False}},
+    )
+    monkeypatch.setattr(
+        eval_dispatch.sys,
+        "argv",
+        ["eval_dispatch.py", str(sprint_dir), "--models", "codex,claude", "--project-root", str(project_root)],
+    )
+
+    assert eval_dispatch.main() == 0
+    assert sorted(calls) == ["claude", "codex"]
+    payload = json.loads((sprint_dir / "issues.json").read_text(encoding="utf-8"))
+    assert sorted(payload["models_valid"]) == ["claude", "codex"]

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -896,6 +896,33 @@ def test_parse_eval_strategy(tmp_path: Path):
     assert malformed_strategy["backpressure_gate"]["result_type"] == "infra_error"
     assert "malformed" in malformed_strategy["backpressure_gate"]["error_reason"].lower()
 
+    quoted_scalar = tmp_path / "quoted.md"
+    quoted_scalar.write_text(
+        "---\n"
+        "backpressure_gate:\n"
+        "  enabled: true\n"
+        "  test_command: python -m pytest\n"
+        "  timeout_seconds: 0.1 # quick gate\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    quoted_strategy = eval_dispatch.parse_eval_strategy(quoted_scalar, {})
+    assert quoted_strategy["backpressure_gate"]["timeout_seconds"] == "0.1 # quick gate"
+    assert eval_dispatch._coerce_timeout(quoted_strategy["backpressure_gate"]["timeout_seconds"]) == 0.1
+
+    quote_error = tmp_path / "quote-error.md"
+    quote_error.write_text(
+        "---\n"
+        "backpressure_gate:\n"
+        "  enabled: 'true\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    quote_error_strategy = eval_dispatch.parse_eval_strategy(quote_error, {})
+    assert quote_error_strategy["backpressure_gate"]["enabled"] is True
+    assert quote_error_strategy["backpressure_gate"]["result_type"] == "infra_error"
+    assert "unterminated" in quote_error_strategy["backpressure_gate"]["error_reason"].lower()
+
 
 def test_run_backpressure_gate(tmp_path: Path):
     sentinel = tmp_path / "sentinel.txt"

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -908,6 +908,21 @@ def test_run_backpressure_gate(tmp_path: Path):
     assert stderr_only["stdout"] == ""
     assert "stderr-only" in stderr_only["stderr"]
 
+    shell_semantics = eval_dispatch.run_backpressure_gate(
+        {
+            "enabled": True,
+            "test_command": (
+                "AHOY_GATE=ok python -c \"import os; print(os.environ['AHOY_GATE'])\" "
+                "> shell-out.txt && test -s shell-out.txt"
+            ),
+            "timeout_seconds": 5,
+        },
+        tmp_path,
+    )
+    assert shell_semantics["result_type"] == "test_result"
+    assert shell_semantics["verdict"] == "pass"
+    assert (tmp_path / "shell-out.txt").read_text(encoding="utf-8").strip() == "ok"
+
     missing = eval_dispatch.run_backpressure_gate(
         {"enabled": True, "test_command": "definitely-not-a-real-ahoy-command", "timeout_seconds": 5},
         tmp_path,

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -867,6 +867,28 @@ def test_parse_eval_strategy(tmp_path: Path):
     assert parsed["backpressure_gate"]["test_command"] == "python -c 'raise SystemExit(1)'"
     assert parsed["backpressure_gate"]["timeout_seconds"] == 3
 
+    spec.write_text(
+        "---\n"
+        "backpressure_gate:\n"
+        "  enabled: false # keep disabled due temp regression\n"
+        "  test_command: \"echo should_not_run\"\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    parsed = eval_dispatch.parse_eval_strategy(spec, {})
+    assert parsed["backpressure_gate"]["enabled"] is False
+
+    spec.write_text(
+        "---\n"
+        "backpressure_gate:\n"
+        "  enabled: true # gate can run in CI\n"
+        "  test_command: \"echo gate\"\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    parsed = eval_dispatch.parse_eval_strategy(spec, {})
+    assert parsed["backpressure_gate"]["enabled"] is True
+
     malformed = tmp_path / "malformed.md"
     malformed.write_text("---\nbackpressure_gate:\n  enabled: [unterminated\n---\n", encoding="utf-8")
     malformed_strategy = eval_dispatch.parse_eval_strategy(malformed, {})

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -932,12 +933,23 @@ def test_run_backpressure_gate(tmp_path: Path):
     assert missing["status_action"] == "error"
     assert missing["exit_code"] == 2
 
+    timeout_start = time.monotonic()
     timeout = eval_dispatch.run_backpressure_gate(
-        {"enabled": True, "test_command": "python -c \"import time; time.sleep(10)\"", "timeout_seconds": 0.1},
+        {
+            "enabled": True,
+            "test_command": (
+                "python -c \"import subprocess, time; "
+                "subprocess.Popen(['python', '-c', 'import time; time.sleep(10)']); "
+                "time.sleep(10)\""
+            ),
+            "timeout_seconds": 0.1,
+        },
         tmp_path,
     )
+    elapsed = time.monotonic() - timeout_start
     assert timeout["result_type"] == "infra_error"
     assert timeout["verdict"] == "error"
     assert timeout["status_action"] == "error"
     assert timeout["exit_code"] == 2
     assert "timeout" in timeout["error_reason"].lower()
+    assert elapsed < 3

--- a/tests/test_eval_dispatch.py
+++ b/tests/test_eval_dispatch.py
@@ -841,3 +841,88 @@ def test_main_round2_quorum_lost_falls_back_to_round1(monkeypatch: pytest.Monkey
     # Round 2 quorum lost -> falls back to round 1, which had a fail -> final fail
     assert payload["verdict"] == "fail"
     assert exit_code == 1
+
+
+def test_parse_eval_strategy(tmp_path: Path):
+    config = {"backpressure_gate": {"enabled": True, "test_command": "python -m pytest", "timeout_seconds": 7}}
+    missing_spec = tmp_path / "missing.md"
+
+    default_strategy = eval_dispatch.parse_eval_strategy(missing_spec, config)
+    assert default_strategy["backpressure_gate"] == {"enabled": True, "test_command": "python -m pytest", "timeout_seconds": 7}
+
+    spec = tmp_path / "spec.md"
+    spec.write_text(
+        "---\n"
+        "backpressure_gate:\n"
+        "  enabled: true\n"
+        "  test_command: \"python -c 'raise SystemExit(1)'\"\n"
+        "  timeout_seconds: 3\n"
+        "---\n"
+        "# Sprint\n",
+        encoding="utf-8",
+    )
+    parsed = eval_dispatch.parse_eval_strategy(spec, {"backpressure_gate": {"enabled": False}})
+    assert parsed["backpressure_gate"]["enabled"] is True
+    assert parsed["backpressure_gate"]["test_command"] == "python -c 'raise SystemExit(1)'"
+    assert parsed["backpressure_gate"]["timeout_seconds"] == 3
+
+    malformed = tmp_path / "malformed.md"
+    malformed.write_text("---\nbackpressure_gate:\n  enabled: [unterminated\n---\n", encoding="utf-8")
+    malformed_strategy = eval_dispatch.parse_eval_strategy(malformed, {})
+    assert malformed_strategy["backpressure_gate"]["enabled"] is True
+    assert malformed_strategy["backpressure_gate"]["result_type"] == "infra_error"
+    assert "malformed" in malformed_strategy["backpressure_gate"]["error_reason"].lower()
+
+
+def test_run_backpressure_gate(tmp_path: Path):
+    sentinel = tmp_path / "sentinel.txt"
+    sentinel.write_text("ok", encoding="utf-8")
+
+    passed = eval_dispatch.run_backpressure_gate(
+        {"enabled": True, "test_command": "python -c \"from pathlib import Path; assert Path('sentinel.txt').exists(); print('pass-out')\"", "timeout_seconds": 5},
+        tmp_path,
+    )
+    assert passed["result_type"] == "test_result"
+    assert passed["verdict"] == "pass"
+    assert passed["status_action"] == "passed"
+    assert passed["exit_code"] == 0
+    assert "pass-out" in passed["stdout"]
+    assert passed["stderr"] == ""
+
+    failed = eval_dispatch.run_backpressure_gate(
+        {"enabled": True, "test_command": "python -c \"import sys; print('fail-out'); sys.exit(1)\"", "timeout_seconds": 5},
+        tmp_path,
+    )
+    assert failed["result_type"] == "test_result"
+    assert failed["verdict"] == "fail"
+    assert failed["status_action"] == "failed"
+    assert failed["exit_code"] == 1
+    assert "fail-out" in failed["stdout"]
+
+    stderr_only = eval_dispatch.run_backpressure_gate(
+        {"enabled": True, "test_command": "python -c \"import sys; print('stderr-only', file=sys.stderr)\"", "timeout_seconds": 5},
+        tmp_path,
+    )
+    assert stderr_only["result_type"] == "test_result"
+    assert stderr_only["verdict"] == "pass"
+    assert stderr_only["stdout"] == ""
+    assert "stderr-only" in stderr_only["stderr"]
+
+    missing = eval_dispatch.run_backpressure_gate(
+        {"enabled": True, "test_command": "definitely-not-a-real-ahoy-command", "timeout_seconds": 5},
+        tmp_path,
+    )
+    assert missing["result_type"] == "infra_error"
+    assert missing["verdict"] == "error"
+    assert missing["status_action"] == "error"
+    assert missing["exit_code"] == 2
+
+    timeout = eval_dispatch.run_backpressure_gate(
+        {"enabled": True, "test_command": "python -c \"import time; time.sleep(10)\"", "timeout_seconds": 0.1},
+        tmp_path,
+    )
+    assert timeout["result_type"] == "infra_error"
+    assert timeout["verdict"] == "error"
+    assert timeout["status_action"] == "error"
+    assert timeout["exit_code"] == 2
+    assert "timeout" in timeout["error_reason"].lower()

--- a/tests/test_validate_harness.py
+++ b/tests/test_validate_harness.py
@@ -802,3 +802,23 @@ def test_hooks_json_covers_all_expected_check_types():
     ]
     for check in expected_checks:
         assert check in combined, f"Missing hook check: {check}"
+
+
+def test_check_post_eval_backpressure_exception(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    write_harness_state(tmp_path, status="generated")
+    payload = issue_payload(verdict="fail", status_action="failed", models_valid=[])
+    payload["result_type"] = "test_result"
+    payload["model_verdicts"] = {}
+    write_issues(tmp_path, payload)
+
+    validate_harness.check_post_eval()
+
+    infra_payload = issue_payload(verdict="error", status_action="error", models_valid=[])
+    infra_payload["result_type"] = "infra_error"
+    infra_payload["model_verdicts"] = {}
+    infra_payload["error_reason"] = "command not found"
+    write_issues(tmp_path, infra_payload)
+
+    with pytest.raises(SystemExit):
+        validate_harness.check_post_eval()

--- a/tests/test_validate_harness.py
+++ b/tests/test_validate_harness.py
@@ -46,7 +46,7 @@ def issue_payload(
     return {
         "evaluated_at": "2026-03-29T00:00:00+00:00",
         "models_used": ["codex", "claude"],
-        "models_valid": models_valid or ["codex", "claude"],
+        "models_valid": ["codex", "claude"] if models_valid is None else models_valid,
         "verdict": verdict,
         "model_verdicts": {"codex": verdict, "claude": verdict},
         "status_action": status_action,
@@ -263,6 +263,25 @@ def test_check_pre_state_write_passes_with_two_valid_models(monkeypatch: pytest.
     validate_harness.check_pre_state_write()
 
     assert (tmp_path / ".claude" / "harness" / "harness_state.json.bak").exists()
+
+
+def test_check_pre_state_write_allows_backpressure_test_failure_only(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    write_harness_state(tmp_path, status="generated")
+    payload = issue_payload(verdict="fail", status_action="failed", models_valid=[])
+    payload["result_type"] = "test_result"
+    payload["model_verdicts"] = {}
+    write_issues(tmp_path, payload)
+
+    validate_harness.check_pre_state_write()
+
+    infra_payload = issue_payload(verdict="error", status_action="error", models_valid=[])
+    infra_payload["result_type"] = "infra_error"
+    infra_payload["model_verdicts"] = {}
+    write_issues(tmp_path, infra_payload)
+
+    with pytest.raises(SystemExit):
+        validate_harness.check_pre_state_write()
 
 
 def test_check_post_state_write_rolls_back_invalid_passed_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Add pre-eval backpressure gate parsing from `.claude/harness/spec.md` YAML frontmatter with config/default fallback and fail-closed malformed handling.
- Run configured test_command in the project root before model evaluation; capture stdout/stderr separately, enforce timeout with terminate→kill, and classify pass/fail/command-not-found/timeout/stderr-only.
- Skip all model subprocess calls when backpressure gate fails or infra-errors; test failures are written as quorum-exempt `issues.json` test_result, while `infra_error` remains fail-closed.
- Preserve existing model quorum/consensus behavior when gate is disabled or passing.

## Tests
Raw logs saved at `/home/home/.hermes/artifacts/daeil_agent_home/ahoy_issue38_raw_pytest_logs.md`.

```text
python -m pytest tests/test_eval_dispatch.py -q
51 passed in 0.20s

python -m pytest tests/test_e2e_integration.py -q
10 passed in 0.06s

python -m pytest tests/test_validate_harness.py -q
53 passed in 0.05s

python -m pytest -q
114 passed in 0.40s
```

## Reviewer constraints
- Tests-first order: `988a6b5` before implementation `09f8739`.
- Backpressure disabled/pass preserves existing model quorum and consensus path.
- `infra_error` blocks with exit 2 and is not quorum-exempt.
- Model subprocess call count is 0 before a failing/infra-error gate result.
